### PR TITLE
[ENH] Print msmbuilder version in osprey worker

### DIFF
--- a/osprey/dataset_loaders.py
+++ b/osprey/dataset_loaders.py
@@ -24,10 +24,8 @@ class MSMBuilderDatasetLoader(BaseDatasetLoader):
     def load(self):
         from msmbuilder.dataset import dataset
         ds = dataset(self.path, mode='r', fmt=self.fmt, verbose=self.verbose)
-        print('Provenance')
-        print('----------')
+        print('Dataset provenance:\n')
         print(ds.provenance)
-        print()
         return ds, None
 
 

--- a/osprey/execute_worker.py
+++ b/osprey/execute_worker.py
@@ -19,6 +19,7 @@ from .config import Config
 from .trials import Trial
 from .fit_estimator import fit_and_score_estimator
 from .utils import Unbuffered, format_timedelta, current_pretty_time
+from .utils import is_msmbuilder_estimator
 
 
 def execute(args, parser):
@@ -34,9 +35,12 @@ def execute(args, parser):
     config_sha1 = config.sha1()
     scoring = config.scoring()
 
-    print('\nLoading dataset...')
+    if is_msmbuilder_estimator(estimator):
+        print_msmbuilder_version()
+
+    print('\nLoading dataset...\n')
     X, y = config.dataset()
-    print('  %d elements with %s labels'
+    print('Dataset contains %d elements with %s labels'
           % (len(X), 'out' if y is None else ''))
     print('Instantiated estimator:')
     print('  %r' % estimator)
@@ -169,11 +173,20 @@ def print_header():
           'hyperparameter optimization. =')
     print('='*70)
     print()
-    print('osprey version:  %s' % __version__)
-    print('time:            %s' % current_pretty_time())
-    print('hostname:        %s' % gethostname())
-    print('cwd:             %s' % os.path.abspath(os.curdir))
-    print('pid:             %s' % os.getpid())
+    print('osprey version:      %s' % __version__)
+    print('time:                %s' % current_pretty_time())
+    print('hostname:            %s' % gethostname())
+    print('cwd:                 %s' % os.path.abspath(os.curdir))
+    print('pid:                 %s' % os.getpid())
+    print()
+
+
+def print_msmbuilder_version():
+    from msmbuilder.version import full_version as msmb_version
+    from mdtraj.version import full_version as mdtraj_version
+    print()
+    print('msmbuilder version:  %s' % msmb_version)
+    print('mdtraj version:      %s' % mdtraj_version)
     print()
 
 

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -3,6 +3,9 @@ import os.path
 import sys
 import contextlib
 from datetime import datetime
+from sklearn.pipeline import Pipeline
+
+from .eval_scopes import import_all_estimators
 
 __all__ = ['dict_merge']
 
@@ -136,3 +139,17 @@ def expand_path(path, base='.'):
     if not os.path.isabs(path):
         path = os.path.join(base, path)
     return path
+
+
+def is_msmbuilder_estimator(estimator):
+    try:
+        import msmbuilder
+    except ImportError:
+        return False
+    msmbuilder_estimators = import_all_estimators(msmbuilder).values()
+
+    out = estimator.__class__ in msmbuilder_estimators
+    if isinstance(estimator, Pipeline):
+        out = any(step.__class__ in msmbuilder_estimators
+                  for name, step in estimator.steps)
+    return out


### PR DESCRIPTION
- Re #69, if the estimator is from msmbuilder, we print the msmbuilder and mdtraj versions in `osprey worker`.
- Also, this PR suppresses the printout of some `DeprecationWarning` during imports, which wasn't being handled correctly before. They're annoying, because they generally are of interest only to developers (e.g. msmbuilder uses statsmodels, and statsmodels uses a deprecated feature of scipy. No reason for osprey users to care about this).